### PR TITLE
Make it Carthage compatible for macOS and tvOS (and still iOS)

### DIFF
--- a/TaskQueue.podspec
+++ b/TaskQueue.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.summary          = "Task management made easy, bounce tasks between main thread and background threads like a pro"
   s.description      = <<-DESC
 	TaskQueue is a Swift library which allows you to schedule tasks once and then let the queue execute them in a synchronous matter. The great thing about TaskQueue is that you get to decide on which GCD queue each of your tasks should execute beforehand and leave TaskQueue to do switching of queues as it goes.
-	
+
 	Even if your tasks are asynchronous like fetching location, downloading files, etc. TaskQueue will wait until they are finished before going on with the next task.
                        DESC
   s.homepage         = "https://github.com/icanzilb/TaskQueue"
@@ -23,8 +23,11 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/icanzilb/TaskQueue.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/icanzilb'
 
-  s.platform     = :ios, '8.0'
   s.requires_arc = true
+
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.11'
+  s.tvos.deployment_target = '9.0'
 
   s.source_files = 'TaskQueue'
 end

--- a/TaskQueue.xcodeproj/project.pbxproj
+++ b/TaskQueue.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		5B2794B01C3B45390030A02A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
@@ -256,6 +257,7 @@
 		5B2794B11C3B45390030A02A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";

--- a/TaskQueue.xcodeproj/project.pbxproj
+++ b/TaskQueue.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/TaskQueue/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilgrimagesoftware.lib.TaskQueue;
 				PRODUCT_NAME = TaskQueue;
@@ -259,7 +259,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/TaskQueue/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilgrimagesoftware.lib.TaskQueue;
 				PRODUCT_NAME = TaskQueue;

--- a/TaskQueue.xcodeproj/project.pbxproj
+++ b/TaskQueue.xcodeproj/project.pbxproj
@@ -231,9 +231,9 @@
 		5B2794B01C3B45390030A02A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 4ER83K7G3W;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -241,19 +241,24 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilgrimagesoftware.lib.TaskQueue;
 				PRODUCT_NAME = TaskQueue;
+				SDKROOT = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
 		5B2794B11C3B45390030A02A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 4ER83K7G3W;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -261,10 +266,15 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilgrimagesoftware.lib.TaskQueue;
 				PRODUCT_NAME = TaskQueue;
+				SDKROOT = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};

--- a/TaskQueue.xcodeproj/project.pbxproj
+++ b/TaskQueue.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilgrimagesoftware.lib.TaskQueue;
 				PRODUCT_NAME = TaskQueue;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -264,7 +264,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilgrimagesoftware.lib.TaskQueue;
 				PRODUCT_NAME = TaskQueue;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/TaskQueue/TaskQueue.swift
+++ b/TaskQueue/TaskQueue.swift
@@ -177,6 +177,17 @@ open class TaskQueue: CustomStringConvertible {
     }
 
     //
+    // pause and reset the current task
+    //
+    open func pauseAndResetCurrentTask() {
+        paused = true
+
+        tasks.insert(currentTask!, at: 0)
+        currentTask = nil
+        self.numberOfActiveTasks -= 1
+    }
+
+    //
     // re-run the current task
     //
     open func retry(_ delay: Double = 0) {


### PR DESCRIPTION
I updated the project settings to make it build on macOS, tvOS, and iOS through the existing scheme. That means that it now works with users who are using Carthage for those platforms too. 

I also added a `pauseAndResetCurrentTask` function that I've been using but I can remove that if you don't want that as part of the library.

Other things:

* Updated `SWIFT_VERSION` to 4.0
* Removed code signing as it's unnecessary
* Updated Podspec to specify `deployment_target`s for iOS, macOS, and tvOS
* Set `APPLICATION_EXTENSION_API_ONLY = YES`